### PR TITLE
Add annotation/chord symbol support ("CM7", "Am", etc.)

### DIFF
--- a/crates/chamber_analyzer/src/rules/bar_length.rs
+++ b/crates/chamber_analyzer/src/rules/bar_length.rs
@@ -173,8 +173,8 @@ impl Rule for BarLength {
                     }
                     bar_end_pos = slur.range.end().into();
                 }
-                MusicElement::GraceNotes(_) => {
-                    // Grace notes don't count toward bar length
+                MusicElement::GraceNotes(_) | MusicElement::Annotation(_) => {
+                    // Grace notes and annotations don't count toward bar length
                 }
                 MusicElement::InlineField(field) => {
                     // TODO: Handle inline M: and L: changes

--- a/crates/chamber_ast/src/lib.rs
+++ b/crates/chamber_ast/src/lib.rs
@@ -90,6 +90,7 @@ pub enum MusicElement {
     BrokenRhythm(BrokenRhythm),
     Tie(Tie),
     InlineField(InlineField),
+    Annotation(Annotation),
 }
 
 /// A single note.
@@ -271,5 +272,13 @@ pub struct InlineField {
     pub label: char,
     /// Field value as text
     pub value: String,
+    pub range: TextRange,
+}
+
+/// An annotation or chord symbol (e.g., "CM7", "Am", "^text").
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Annotation {
+    /// The annotation text (without quotes)
+    pub text: String,
     pub range: TextRange,
 }

--- a/crates/chamber_lexer/src/lexer.rs
+++ b/crates/chamber_lexer/src/lexer.rs
@@ -209,6 +209,15 @@ impl<'a> Lexer<'a> {
                 }
             }
 
+            // Annotations/chord symbols ("CM7", "Am", etc.)
+            '"' => {
+                if self.in_header {
+                    self.text()
+                } else {
+                    self.annotation()
+                }
+            }
+
             // Everything else in header context is text
             _ if self.in_header => self.text(),
 
@@ -392,6 +401,23 @@ impl<'a> Lexer<'a> {
             self.advance();
         }
         // Unterminated decoration (reached EOF)
+        TokenKind::Error
+    }
+
+    fn annotation(&mut self) -> TokenKind {
+        // Consume annotation text until closing double quote
+        while let Some(c) = self.peek() {
+            if c == '"' {
+                self.advance(); // consume closing quote
+                return TokenKind::Annotation;
+            }
+            if c == '\n' || c == '\r' {
+                // Unterminated annotation
+                return TokenKind::Error;
+            }
+            self.advance();
+        }
+        // Unterminated annotation (reached EOF)
         TokenKind::Error
     }
 }

--- a/crates/chamber_lexer/src/token.rs
+++ b/crates/chamber_lexer/src/token.rs
@@ -84,6 +84,8 @@ pub enum TokenKind {
     Tuplet,
     /// Decoration (!trill!, +fermata+, etc.)
     Decoration,
+    /// Annotation/chord symbol ("CM7", "Am", etc.)
+    Annotation,
 
     // Text and numbers
     /// Plain text content
@@ -152,6 +154,7 @@ impl TokenKind {
             TokenKind::BrokenRhythm => SyntaxKind::BROKEN_RHYTHM,
             TokenKind::Tuplet => SyntaxKind::TUPLET_MARKER,
             TokenKind::Decoration => SyntaxKind::DECORATION,
+            TokenKind::Annotation => SyntaxKind::ANNOTATION,
             TokenKind::Text => SyntaxKind::TEXT,
             TokenKind::Number => SyntaxKind::NUMBER,
             TokenKind::Slash => SyntaxKind::SLASH,

--- a/crates/chamber_parser/src/cst_parser.rs
+++ b/crates/chamber_parser/src/cst_parser.rs
@@ -186,6 +186,15 @@ impl<'a> CstParser<'a> {
                 )))
             }
 
+            // Annotation/chord symbol
+            SyntaxKind::ANNOTATION => {
+                let token = self.advance()?;
+                Some(CstChild::Node(CstNode::with_children(
+                    SyntaxKind::ANNOTATION_NODE,
+                    vec![CstChild::Token(token)],
+                )))
+            }
+
             // Tie
             SyntaxKind::TIE => {
                 let token = self.advance()?;

--- a/crates/chamber_parser/src/parser.rs
+++ b/crates/chamber_parser/src/parser.rs
@@ -609,6 +609,7 @@ impl<'a, S: DiagnosticSink> Parser<'a, S> {
             TokenKind::LeftBrace => self.parse_grace_notes().map(MusicElement::GraceNotes),
             TokenKind::BrokenRhythm => self.parse_broken_rhythm().map(MusicElement::BrokenRhythm),
             TokenKind::Tie => self.parse_tie().map(MusicElement::Tie),
+            TokenKind::Annotation => self.parse_annotation().map(MusicElement::Annotation),
             TokenKind::Decoration => {
                 // Look ahead past decorations to find what element follows
                 let element_kind = self.peek_past_decorations();
@@ -1217,6 +1218,25 @@ impl<'a, S: DiagnosticSink> Parser<'a, S> {
         }
 
         Some(Tie { range: token.range })
+    }
+
+    fn parse_annotation(&mut self) -> Option<Annotation> {
+        let token = self.advance()?;
+        if token.kind != TokenKind::Annotation {
+            return None;
+        }
+
+        let raw_text = self.token_text(&token);
+        // Remove surrounding double quotes
+        let text = raw_text
+            .trim_start_matches('"')
+            .trim_end_matches('"')
+            .to_string();
+
+        Some(Annotation {
+            text,
+            range: token.range,
+        })
     }
 
     // Helper methods

--- a/crates/chamber_parser/tests/main.rs
+++ b/crates/chamber_parser/tests/main.rs
@@ -767,3 +767,83 @@ fn test_notes_with_and_without_decorations() {
         other => panic!("Expected Note, got {:?}", other),
     }
 }
+
+// ============================================
+// Annotations (chord symbols)
+// ============================================
+
+#[test]
+fn test_simple_annotation() {
+    let tune = parse("X:1\nK:C\n\"CM7\"C");
+
+    match &tune.body.elements[0] {
+        MusicElement::Annotation(ann) => {
+            assert_eq!(ann.text, "CM7");
+        }
+        other => panic!("Expected Annotation, got {:?}", other),
+    }
+
+    match &tune.body.elements[1] {
+        MusicElement::Note(note) => {
+            assert_eq!(note.pitch, Pitch::C);
+        }
+        other => panic!("Expected Note, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_annotation_with_space() {
+    let tune = parse("X:1\nK:C\n\"Am7\" C E G");
+
+    match &tune.body.elements[0] {
+        MusicElement::Annotation(ann) => {
+            assert_eq!(ann.text, "Am7");
+        }
+        other => panic!("Expected Annotation, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_multiple_annotations() {
+    let tune = parse("X:1\nK:C\n\"C\"C \"G\"G");
+
+    // First annotation
+    match &tune.body.elements[0] {
+        MusicElement::Annotation(ann) => {
+            assert_eq!(ann.text, "C");
+        }
+        other => panic!("Expected Annotation at 0, got {:?}", other),
+    }
+
+    // First note
+    match &tune.body.elements[1] {
+        MusicElement::Note(note) => {
+            assert_eq!(note.pitch, Pitch::C);
+        }
+        other => panic!("Expected Note at 1, got {:?}", other),
+    }
+
+    // Second annotation
+    match &tune.body.elements[2] {
+        MusicElement::Annotation(ann) => {
+            assert_eq!(ann.text, "G");
+        }
+        other => panic!("Expected Annotation at 2, got {:?}", other),
+    }
+
+    // Second note
+    match &tune.body.elements[3] {
+        MusicElement::Note(note) => {
+            assert_eq!(note.pitch, Pitch::G);
+        }
+        other => panic!("Expected Note at 3, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_annotation_no_error() {
+    let result = parse_with_diagnostics("X:1\nT:Test\nK:C\n\"CM7\" C E G B |");
+
+    // Should not have any errors about unexpected character
+    assert!(!result.has_errors());
+}

--- a/crates/chamber_syntax/src/kind.rs
+++ b/crates/chamber_syntax/src/kind.rs
@@ -83,6 +83,8 @@ pub enum SyntaxKind {
     TUPLET_MARKER,
     /// Decoration (!trill!, +fermata+, etc.)
     DECORATION,
+    /// Annotation/chord symbol ("CM7", "Am", etc.)
+    ANNOTATION,
     /// Number
     NUMBER,
     /// Slash (/)
@@ -143,6 +145,8 @@ pub enum SyntaxKind {
     ACCIDENTAL,
     /// Decoration (!trill!)
     DECORATION_NODE,
+    /// Annotation/chord symbol ("CM7")
+    ANNOTATION_NODE,
 }
 
 impl SyntaxKind {

--- a/examples/errors/music/unclosed_annotation.abc
+++ b/examples/errors/music/unclosed_annotation.abc
@@ -1,0 +1,5 @@
+X:1
+T:Unclosed Annotation
+K:C
+% L001: Missing closing double quote
+"CM7 C E G B |

--- a/examples/valid/annotations.abc
+++ b/examples/valid/annotations.abc
@@ -1,0 +1,15 @@
+X:1
+T:Annotation Examples
+M:4/4
+L:1/4
+K:C
+% Chord symbols (most common use)
+"C"C E G c | "G7"B, D G B | "Am"A, C E A | "F"F, A c f |
+% Jazz chords
+"CM7"C E G B | "Dm7"D F A c | "G7"G, B, D F | "CM7"C4 |
+% Multiple annotations in sequence
+"C"C "Am"A "F"F "G"G |
+% Annotations with various note values
+"Em"E2 G2 | "D"D4 |
+% Positioning annotations (ABC standard prefixes)
+"^above"C2 "_below"D2 | "<left"E2 ">right"F2 | "@free"G4 |


### PR DESCRIPTION
- Add TokenKind::Annotation and SyntaxKind::ANNOTATION
- Add lexer support for double-quoted strings in tune body
- Add Annotation struct to AST and MusicElement::Annotation variant
- Add parser support in both direct parser and CST parser
- Exclude annotations from bar length calculation
- Add tests and example files

🤖 Generated with [Claude Code](https://claude.com/claude-code)